### PR TITLE
Replace `gulp-util` with `plugin-error`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var through = require('through2');
 var _ = require('lodash');
 var cheerio = require("cheerio");
@@ -25,7 +25,7 @@ module.exports = function( options ) {
 		}
 
 		if( file.isStream() ) {
-			cb(new gutil.PluginError( PLUGIN_NAME, 'Streaming not supported'));
+			cb(new PluginError( PLUGIN_NAME, 'Streaming not supported' ));
 			return;
 		}
 		

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "ISC",
   "dependencies": {
     "cheerio": "^0.19.0",
-    "gulp-util": "^3.0.6",
+    "plugin-error": "^1.0.1",
     "lodash": "^3.10.1",
     "through2": "^2.0.0"
   },


### PR DESCRIPTION
The [`gulp-util` package](https://www.npmjs.com/package/gulp-util) which this library depends on has been deprecated:

> ```
> npm WARN deprecated gulp-util@3.0.8: gulp-util is deprecated - replace it,
> following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
> ```
According to the [webpage mentioned](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5):

> #### Why deprecation now?
>
> We’ve been planning to deprecate gulp-util since 2014 because it’s just grab-bag of modules. Why would you want to download the beeper module if you’re only using gulp-util for logging? It drastically increases the download size of plugins and gulp itself.

This package uses `gulp-util` only because of `PluginError`, which should now be imported from the [`plugin-error` package](https://www.npmjs.com/package/plugin-error).

This PR gets rid of the above package installation warning by replacing `gulp-util` with `plugin-error`.